### PR TITLE
workaround timestamp is null error, added reading of 1-0:32.7.0 (not …

### DIFF
--- a/lib/parsePacket.js
+++ b/lib/parsePacket.js
@@ -324,6 +324,9 @@ function parsePacket(packet) {
                 case "0-4:24.4.0":
                     parsedPacket.gas.valvePosition = line.value;
                     break;
+                case "1-0:32.7.0":
+                    // dont really know what it is, but looks like voltage...
+                    break;
 
                 default:
                     console.error('Unable to parse line: ' + lines[i]);
@@ -366,6 +369,9 @@ function _parseLine(line) {
  * @param timestamp : Timestamp of format: YYMMDDhhmmssX
  */
 function _parseTimestamp(timestamp) {
+    if (typeof timestamp !== 'string') {
+        return timestamp;
+    }
     var parsedTimestamp = new Date();
 
     parsedTimestamp.setFullYear(parseInt(timestamp.substring(0, 2)) + 2000);


### PR DESCRIPTION
…actually added but ignored so log is not spammed)